### PR TITLE
Run all models

### DIFF
--- a/formal/promela/models/models.yml
+++ b/formal/promela/models/models.yml
@@ -1,0 +1,4 @@
+barriers: barriers/barrier-mgr-model
+chains: chains/chains-api-model
+events: events/event-mgr-model
+messages: messages/msg-mgr-model

--- a/formal/promela/src/testbuilder-template.yml
+++ b/formal/promela/src/testbuilder-template.yml
@@ -31,6 +31,7 @@
 # All pathnames should be absolute
 
 spin2test: <spin2test_directory>/spin2test.py
+modelsfile: <formal_directory>/promela/models/models.yml
 rtems: <path-to-main-rtems-directory>  # rtems.git, or ..../modules/rtems/
 rsb: <rsb-build_directory>/rtems/6/bin/
 simulator: <path-to>/sparc-rtems6-sis

--- a/formal/promela/src/testbuilder.help
+++ b/formal/promela/src/testbuilder.help
@@ -8,8 +8,7 @@ In order to generate test files the following input files are required:
     `<model>-run.h`
 where `<model>` is the name of the model.
 
-`allsteps <model>` will run clean, spin, gentests, copy, compile and run
-`models` will run clean, spin, gentests, copy, compile and run for all models
+`allsteps [<model> | allmodels | <list of models>]` will run clean, spin, gentests, copy, compile and run for desired model(s)
 `spin <model>` will run SPIN to find all scenarios
 `gentests <model>` will produce C tests
 `clean <model>` will remove generated files.

--- a/formal/promela/src/testbuilder.help
+++ b/formal/promela/src/testbuilder.help
@@ -8,7 +8,8 @@ In order to generate test files the following input files are required:
     `<model>-run.h`
 where `<model>` is the name of the model.
 
-`all <model>` will run clean, spin, gentests, copy, compile and run
+`allsteps <model>` will run clean, spin, gentests, copy, compile and run
+`models` will run clean, spin, gentests, copy, compile and run for all models
 `spin <model>` will run SPIN to find all scenarios
 `gentests <model>` will produce C tests
 `clean <model>` will remove generated files.

--- a/formal/promela/src/testbuilder.py
+++ b/formal/promela/src/testbuilder.py
@@ -58,10 +58,12 @@ def all_steps(model, config, refine_config):
     copy(sys.argv[2], config["testcode"], config["rtems"],
          config["testyaml"], config["testsuite"])
     compile(config["rtems"])
-    run_simulator(config["simulator"],
-                  config["simulatorargs"], config["testexe"], config["testsuite"])
+    run_simulator(config["simulator"], config["simulatorargs"],
+                  config["testexe"], config["testsuite"])
+
 
 def all_models(config, source_dir, model_to_path):
+    cwd = os.getcwd()
     for model, path in model_to_path.items():
         refine_config = get_refine_config(source_dir, model)
         os.chdir(path)
@@ -70,11 +72,10 @@ def all_models(config, source_dir, model_to_path):
         generate_test_files(model, config["spin2test"], refine_config)
         copy(model, config["testcode"], config["rtems"],
              config["testyaml"], config["testsuite"])
-
+    os.chdir(cwd)
     compile(config["rtems"])
     run_simulator(config["simulator"], config["simulatorargs"],
                   config["testexe"], config["testsuite"])
-
 
 
 def clean(model, testsuite, test_extension):
@@ -148,6 +149,7 @@ def generate_spin_files(model, spinallscenarios, refine_config):
                            check=True, shell=True)
     os.remove('pan')
 
+
 @catch_subprocess_errors
 def generate_test_files(model, testgen, refine_config):
     """Create test files from spin files"""
@@ -200,8 +202,6 @@ def generate_testcase_file(model, refine_config, no_of_trails):
         for file in missing_files:
             print(f"File not found: {file}")
         print(f"tc-{model}.c will not be generated")
-
-
 
 
 def copy(model, codedir, rtems, modfile, testsuite_name):


### PR DESCRIPTION
- Added ability to run any testbuilder.py from any location
- Added ability to run allsteps command on a model, selection of models, or all models

```
tbuild allsteps allmodels - run all steps on all models defined in model.yml
tbuild allsteps <modelname> - run all steps on <modelname>
tbuild allsteps <modelname_one> ... <modelname_n> - run all steps on all models specified from one to n
```
Note: I made a change that requires models.yml to be present, and contain your model.
Otherwise for testbuilder.py will be unable to find your model.